### PR TITLE
fix: declare Vue as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "fuse.js": "^7.0.0",
     "nanoid": "^5.0.6"
   },
+  "peerDependencies": {
+    "vue": "^3.4.0"
+  },
   "devDependencies": {
     "@iconify/json": "^2.2.189",
     "@microsoft/api-extractor": "^7.42.3",


### PR DESCRIPTION
## Summary
- add `vue` to `peerDependencies` for the published library package
- keep `vue` in `devDependencies` for local builds and type checks

The library imports from `vue`, and the Vite library build already externalizes `vue`, so consumers should receive an explicit peer dependency declaration.

## Verification
- `npx pnpm@8.15.9 install --frozen-lockfile`
- `npx pnpm@8.15.9 run build:lib`
- `npx pnpm@8.15.9 pack --pack-destination C:\tmp\vue-command-palette`
- verified the packed `package/package.json` includes `peerDependencies.vue`